### PR TITLE
Sorry my bad, this actually makes the npm scripts work on windows!

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         .use(freesewing.plugins.debug)
         .use(freesewing.plugins.theme)
         .use(freesewing.plugins.designer)
-        .use(freesewing.plugins.validate)
+        .use(freesewing.plugins.validate);
 
       pattern.draft();
       document.getElementById("svg").innerHTML = pattern.render();

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "clean": "rimraf dist",
     "pretty": "npx prettier --write 'src/*.js'",
     "lint": "eslint --fix 'src/*.js'",
-    "browserbuild": "rollup -c rollup.config.js -o dist/browser.js -f iife -m true -n freesewing_patterns_template --footer 'freesewing.patterns.template=freesewing_patterns_template;'",
+    "browserbuild": "rollup -c rollup.config.js -o dist/browser.js -f iife -m true -n freesewing_patterns_template --footer \"freesewing.patterns.template = freesewing_patterns_template;\"",
     "nodebuild": "rollup -c rollup.config.js -o dist/index.js -f cjs -m true",
     "modulebuild": "rollup -c rollup.config.js -o dist/index.mjs -f es -m true",
     "build": "npm run clean && npm run browserbuild && npm run nodebuild && npm run modulebuild"


### PR DESCRIPTION
I noticed that the rollup footer was not actually getting appended to the browser build. Using escaped double quotes `\"` rather single quotes `'` for nested scripts makes it cross-platform compatible. 